### PR TITLE
Do not autoescape static tags

### DIFF
--- a/django_tiptap/__init__.py
+++ b/django_tiptap/__init__.py
@@ -1,3 +1,3 @@
 """TipTap Editor in Django 🚀"""
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/django_tiptap/templates/forms/tiptap_textarea.html
+++ b/django_tiptap/templates/forms/tiptap_textarea.html
@@ -444,7 +444,7 @@
 
     // {% for custom_extension in widget.config.custom_extensions %}
         // {% if custom_extension.source_static %}
-            import {{ '{' }} {{ custom_extension.module_name }} {{ '}' }} from '{% static custom_extension.source_static %}'
+            import {{ '{' }} {{ custom_extension.module_name }} {{ '}' }} from '{% autoescape off %}{% static custom_extension.source_static %}{% endautoescape %}'
         // {% else %}
             import {{ '{' }}  {{ custom_extension.module_name }}  {{ '}' }} from '{{ custom_extension.source_url }}'
         // {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=2,<4", "setuptools"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
The URL generated by the `static`-template tag was automatically escaped. This lead to '&'s being replaced with '&amp;', which broke some static storage backends, for example s3 signed urls.

Additionally this PR adds the setuptools-dependency to the pyproject.toml, which allows this package to be installed "editable" (`pip install -e`), which is incredibly useful for development