### PR TITLE
added widget.config.output_html option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ DJANGO_TIPTAP_CONFIG = {
         "add": "Add"
     },
     "custom_extensions": [],
-    "outputHtml": True  # True for HTML output of editor, False for JSON
+    "tiptapOutputFormat": "html",  # options : "html", "json"
 
 }
 ```

--- a/django_tiptap/config.py
+++ b/django_tiptap/config.py
@@ -27,7 +27,7 @@ TIPTAP_DEFAULT_CONFIG = {
     "unsavedChangesWarningText": None,
     "lang": "EN",
     "custom_extensions": [],
-    "outputHtml": True,
+    "tiptapOutputFomat": "html",
 }
 
 TIPTAP_DEFAULT_TOOLTIPS = {

--- a/django_tiptap/templates/forms/tiptap_textarea.html
+++ b/django_tiptap/templates/forms/tiptap_textarea.html
@@ -440,10 +440,10 @@
     // {% if 'jinjaSyntaxHighlight' in widget.config.extensions%}
     import { Decoration, DecorationSet } from "https://cdn.skypack.dev/pin/prosemirror-view@v1.18.7-Oooie68ouAI0drFC4VJg/mode=imports,min/optimized/prosemirror-view.js"
     // {% endif %}
-    // {% if widget.config.outputHtml %}
+    // {% if widget.config.tiptapOutputFormat == "html" %}
     import marked from 'https://cdn.skypack.dev/pin/marked@v2.0.3-qfnC6uYDZMsP0gC4iyi0/mode=imports,min/optimized/marked.js'
     // {% endif %}
-    
+
 
     // {% for custom_extension in widget.config.custom_extensions %}
         // {% if custom_extension.source_static %}
@@ -1014,9 +1014,9 @@
     }
 
     const textArea = document.querySelector('#{{ widget.name }}-tiptap-editor-textarea')
-    // {% if widget.config.outputHtml %}
+    // {% if widget.config.tiptapOutputFormat == "html" %}
     let initialEditorContent = marked(textArea.value.trim())
-    // {% else %}
+    // {% elif widget.config.tiptapOutputFormat == "json" %}
     let initialEditorContent = JSON.parse(textArea.value)
     // {% endif %}
 
@@ -1153,9 +1153,9 @@
         content: initialEditorContent,
         onUpdate({ editor }) {
             checkIsActive(editor)
-             // {% if widget.config.outputHtml %}
+             // {% if widget.config.tiptapOutputFormat == "html" %}
             const currentEditorContent = editor.getHTML().trim()
-            // {% else %} 
+            // {% elif widget.config.tiptapOutputFormat == "json" %}
             const currentEditorContent = JSON.stringify(editor.getJSON());
             // {% endif %}
             textArea.value = currentEditorContent


### PR DESCRIPTION
Hello,

Tiptap output can be either html or json object.
I added a config option `outputHtml: True`  for html output and  `outputHtml: False` for json.

Please review.